### PR TITLE
fix: avoid recursion in personal complement calculation

### DIFF
--- a/domain/salary.go
+++ b/domain/salary.go
@@ -54,7 +54,18 @@ func AnnualPersonalComplement(input PayrollInput) int {
 	if input.BaseSalary <= 0 || input.GrossSalary <= 0 {
 		return 0
 	}
-	return input.GrossSalary - AnnualGrossSalaryWithExtras(input)
+
+	knownAnnual := (input.BaseSalary * 12)
+	for _, c := range input.SalaryComplements {
+		knownAnnual += c * 12
+	}
+	knownAnnual += AnnualExtraPayments(input)
+
+	diff := input.GrossSalary - knownAnnual
+	if diff < 0 {
+		return 0
+	}
+	return diff
 }
 
 // MonthlyPersonalComplement returns the monthly personal complement amount in cents


### PR DESCRIPTION
- Refactored AnnualPersonalComplement and MonthlyPersonalComplement to depend on input.GrossSalary only if provided.
- Prevents recursive calls between MonthlyGrossSalary and MonthlyPersonalComplement.
- Ensures correct calculation when GrossSalary is supplied and safe fallback when not.